### PR TITLE
Deprecetion Warning

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,7 +14,8 @@ mongoose.Promise = global.Promise;
 mongoose.connect(config.db, {
   useNewUrlParser: true,
   useUnifiedTopology: true,
-  useCreateIndex: true
+  useCreateIndex: true,
+  useFindAndModify:false
 });
 
 let db = mongoose.connection;


### PR DESCRIPTION
To avoid deprecetion warning added useFindAndModify:false to mongodb connection globally
 Mongoose: `findOneAndUpdate()` and `findOneAndDelete()` without the `useFindAndModify` option set to false are deprecated. See: https://mongoosejs.com/docs/deprecations.html#findandmodify
(Use `node --trace-deprecation ...` to show where the warning was created)